### PR TITLE
Use mimalloc in rust benchmarks

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -410,6 +410,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "irc-rust",
+ "mimalloc",
  "twitch",
  "twitch-irc",
 ]
@@ -469,6 +470,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 criterion = "0.5.1"
 irc-rust = "0.4.0"
+mimalloc = { version = "0.1.37", default-features = false }
 twitch = { git = "https://github.com/jprochazk/twitch-rs.git", version = "0.1.0", features = [
   "simd",
 ] }

--- a/rust/benches/parse.rs
+++ b/rust/benches/parse.rs
@@ -1,6 +1,9 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use mimalloc::MiMalloc;
 use std::str::FromStr;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn read_input() -> Vec<String> {
     let data = include_str!("../../data.txt");


### PR DESCRIPTION
Free performance
```
twitch/data.txt (whitelist)
                        time:   [225.37 µs 225.50 µs 225.66 µs]
                        change: [-7.0355% -6.5644% -6.1261%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

twitch/data.txt (no whitelist)
                        time:   [278.90 µs 279.03 µs 279.16 µs]
                        change: [-10.326% -10.101% -9.8622%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe

twitch_irc/data.txt     time:   [2.9610 ms 2.9726 ms 2.9851 ms]
                        change: [-18.568% -18.165% -17.700%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

Benchmarking irc_rust/data.txt: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
irc_rust/data.txt       time:   [1.6890 ms 1.6916 ms 1.6950 ms]
                        change: [-6.6009% -6.3900% -6.1671%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```
As expected, allocation-heavy benches benefit from this more than others