### PR TITLE
Uncomment TwitchLib parsing. Set iteration count to 15

### DIFF
--- a/dotnet/ComparisonBenchmarks.cs
+++ b/dotnet/ComparisonBenchmarks.cs
@@ -28,12 +28,12 @@ public class ComparisonBenchmarks
         }
     }
 
-    /* [Benchmark]
+    [Benchmark, IterationCount(15), WarmupCount(5)]
     public void TwitchLibParse()
     {
         foreach (string item in stringLines)
         {
             TwitchLib.HandleIrcMessage(TwitchLib.ParseIrcMessage(item));
         }
-    } */
+    }
 }


### PR DESCRIPTION
This will make TwitchLib parsing actually stop after 15 iterations and not go on forever