### PR TITLE
Add Elixir benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ JVM benchmarks use [Java Microbenchmark Harness (JMH)](https://openjdk.org/proje
 $ cd jvm && ./gradlew jmh
 ```
 
+### Elixir
+
+[Install Elixir](https://elixir-lang.org/install.html)
+
+```
+$ cd elixir && mix deps.get && mix test
+```
+
 ## Results
 
 ### x86

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -16,4 +16,7 @@ cd go && go test -bench=. >> ../output/go.txt && cd ..
 echo "\nRunning Node.js..."
 cd node && npm i && node bench.js >> ../output/node.txt && cd ..
 
+echo "\nRunning Elixir.."
+cd elixir && mix deps.get && mix test
+
 # TODO: iterate through result files and parse them into a round summary

--- a/elixir/.formatter.exs
+++ b/elixir/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+twitch_bench-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,0 +1,21 @@
+# TwitchBench
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `twitch_bench` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:twitch_bench, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/twitch_bench>.
+

--- a/elixir/lib/twitch_bench.ex
+++ b/elixir/lib/twitch_bench.ex
@@ -1,0 +1,200 @@
+defmodule Parser do
+  def parse_irc(line) do
+    if String.first(line) != "@" do
+      raise "invalid format"
+    end
+
+    # [tags | rest] = String.split(line, " ")
+    tags = String.split(line, " ") |> List.first()
+    String.slice(tags, 1..-1) |> parse_tags
+  end
+
+  def parse_tags(tags) do
+    tags
+    |> String.split(";")
+    |> Enum.map(fn raw_tag -> Parser.tag_mapper(raw_tag) end)
+  end
+
+  def tag_mapper(raw_tag) do
+    raw_tag = String.split(raw_tag, "=")
+
+    case raw_tag do
+      ["badge-info", value] ->
+        %{type: :badgeInfo, value: value}
+
+      ["badge-info"] ->
+        %{type: :badgeInfo, value: nil}
+
+      ["badges", value] ->
+        %{type: :badges, value: String.split(value, ",")}
+
+      ["badges"] ->
+        %{type: :badges, value: nil}
+
+      ["color", value] ->
+        %{type: :color, value: value}
+
+      ["display-name", value] ->
+        %{type: :displayName, value: value}
+
+      ["emotes"] ->
+        %{type: :emotes, value: nil}
+
+      ["emotes", value] ->
+        %{type: :emotes, value: String.split(value, "/")}
+
+      ["id", value] ->
+        %{type: :id, value: value}
+
+      ["mod", "1"] ->
+        %{type: :mod, value: true}
+
+      ["mod", "0"] ->
+        %{type: :mod, value: false}
+
+      ["reply-parent-msg-id", value] ->
+        %{type: :replyMessageId, value: value}
+
+      ["reply-parent-user-id", value] ->
+        %{type: :replyUserId, value: value}
+
+      ["reply-parent-user-login", value] ->
+        %{type: :replyUserId, value: value}
+
+      ["reply-parent-display-name", value] ->
+        %{type: :replyDisplayName, value: value}
+
+      ["reply-parent-msg-body", value] ->
+        %{type: :replyMessageBody, value: value}
+
+      ["reply-parent-msg-body", ""] ->
+        %{type: :replyMessageBody, value: ""}
+
+      ["reply-parent-msg-body"] ->
+        %{type: :replyMessageBody, value: ""}
+
+      ["room-id", value] ->
+        %{type: :roomId, value: value}
+
+      ["subscriber", "1"] ->
+        %{type: :subscriber, value: true}
+
+      ["subscriber", "0"] ->
+        %{type: :subscriber, value: false}
+
+      ["tmi-sent-ts", value] ->
+        %{type: :tmiSentTs, value: value}
+
+      ["turbo", "1"] ->
+        %{type: :turbo, value: true}
+
+      ["turbo", "0"] ->
+        %{type: :turbo, value: false}
+
+      ["user-id", value] ->
+        %{type: :userId, value: value}
+
+      ["user-type"] ->
+        %{type: :userType, value: :normal}
+
+      ["user-type", ""] ->
+        %{type: :userType, value: :normal}
+
+      ["user-type", "mod"] ->
+        %{type: :userType, value: :moderator}
+
+      ["user-type", "admin"] ->
+        %{type: :userType, value: :admin}
+
+      ["user-type", "global_mod"] ->
+        %{type: :userType, value: :globalMod}
+
+      ["user-type", "staff"] ->
+        %{type: :userType, value: :staff}
+
+      ["vip", "1"] ->
+        %{type: :vip, value: true}
+
+      ["first-msg", "1"] ->
+        %{type: :firstMessage, value: true}
+
+      ["first-msg", "0"] ->
+        %{type: :firstMessage, value: false}
+
+      ["returning-chatter", "1"] ->
+        %{type: :returningChatter, value: true}
+
+      ["returning-chatter", "0"] ->
+        %{type: :returningChatter, value: false}
+
+      ["flags", ""] ->
+        %{type: :flags, value: nil}
+
+      ["flags", value] ->
+        %{type: :flags, value: String.split(value, ",")}
+
+      ["emote-only", "1"] ->
+        %{type: :emoteOnly, value: true}
+
+      ["emote-only", "0"] ->
+        %{type: :emoteOnly, value: false}
+
+      ["emote-only"] ->
+        %{type: :emoteOnly, value: false}
+
+      ["client-nonce", value] ->
+        %{type: :clientNonce, value: value}
+
+      ["ban-duration", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :banDuration, value: value}
+
+      ["target-user-id", value] ->
+        %{type: :targetUserId, value: value}
+
+      ["login", value] ->
+        %{type: :login, value: value}
+
+      ["msg-id", value] ->
+        %{type: :messageId, value: value}
+
+      ["msg-param-cumulative-months", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :messageParamCumMonths, value: value}
+
+      ["msg-param-months", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :messageParamMonths, value: value}
+
+      ["msg-param-multimonth-duration", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :messageParamMultiMonthDuration, value: value}
+
+      ["msg-param-multimonth-tenure", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :messageParamMultiMonthTenure, value: value}
+
+      ["msg-param-should-share-streak", value] ->
+        {value, _} = Integer.parse(value)
+        %{type: :messageParamShouldShareStreak, value: value}
+
+      ["msg-param-sub-plan-name", value] ->
+        %{type: :messageParamSubPlanName, value: value}
+
+      ["msg-param-sub-plan", value] ->
+        %{type: :messageParamSubPlan, value: value}
+
+      ["msg-param-was-gifted", "true"] ->
+        %{type: :messageParamWasGifted, value: true}
+
+      ["msg-param-was-gifted", "false"] ->
+        %{type: :messageParamWasGifted, value: false}
+
+      ["system-msg", value] ->
+        %{type: :systemMessage, value: value}
+
+      ["sent-ts", value] ->
+        %{type: :sentTs, value: value}
+    end
+  end
+end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -1,0 +1,29 @@
+defmodule TwitchBench.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :twitch_bench,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:benchee, "~> 1.0"}
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/elixir/mix.lock
+++ b/elixir/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "benchee": {:hex, :benchee, "1.3.0", "f64e3b64ad3563fa9838146ddefb2d2f94cf5b473bdfd63f5ca4d0657bf96694", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "34f4294068c11b2bd2ebf2c59aac9c7da26ffa0068afdf3419f1b176e16c5f81"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
+}

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/elixir/test/twitch_bench_test.exs
+++ b/elixir/test/twitch_bench_test.exs
@@ -1,0 +1,11 @@
+defmodule TwitchBenchTest do
+  use ExUnit.Case
+
+  test "run bench" do
+    data = File.read!("data.txt") |> String.split("\n") |> Enum.take(1000)
+
+    Benchee.run(%{
+      "parse_irc" => fn -> Enum.map(data, fn line -> Parser.parse_irc(line) end) end
+    })
+  end
+end


### PR DESCRIPTION
Pretty close to a 1:1 port of the [Gleam code](https://github.com/jprochazk/twitch-irc-benchmarks/blob/e8fcfd13e2c7c481c733152e0e323085b7df6eeb/gleam/src/orange_tmi.gleam) minus the typedefs. Uses tagged maps instead.